### PR TITLE
fix: show relevant-search-results while user removes alphabets in search input

### DIFF
--- a/src/components/Dashboard/LeaderBoardWrapper.tsx
+++ b/src/components/Dashboard/LeaderBoardWrapper.tsx
@@ -26,7 +26,8 @@ type propsType = {
 
 const LeaderBoardWrapper = ({ dashboardData }: propsType) => {
   const [wordEntered, setWordEntered] = React.useState('');
-  const [data, setData] = React.useState(dashboardData);
+  const sourceData = dashboardData || [];
+  const [data, setData] = React.useState(sourceData);
   const [searching, _setSearching] = React.useState(false);
   const {
     allXPData,
@@ -43,11 +44,11 @@ const LeaderBoardWrapper = ({ dashboardData }: propsType) => {
   const handleSearch = (event: { target: { value: any } }) => {
     const searchWord = event.target.value;
     setWordEntered(searchWord);
-    const newFilter = data.filter((value: { name: string }) => {
+    const newFilter = sourceData.filter((value: { name: string }) => {
       return value.name.toLowerCase().includes(searchWord.toLowerCase());
     });
     if (searchWord === '') {
-      setData(dashboardData);
+      setData(sourceData);
     } else {
       setData(newFilter);
     }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  new: For new features
  improve: For an improvement (performance or little improvements) in existing features
  fix: For bug fixes that affect the end-user
  break: For pull requests including breaking changes
  chore: For small tasks
  doc: For documentation
  design: For design/UX improvement
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
  - I have read the Contributing Guide - https://github.com/irffanasiff/Superteam-Reputation/tree/prod/.github/CONTRIBUTING.md doc
  - I have added necessary documentation (if applicable)
-->

## Proposed changes
https://user-images.githubusercontent.com/65857855/206908173-7b4eda9a-951e-411e-9c5f-05ccd74a956f.mov


<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue: 
[ Fix: Seach bar #5 ](https://github.com/SuperteamDAO/superteam-reputation/issues/5)

## Further comments
1. fix: the filtering was being done on the state variable(`data`), instead of the response from API(`dashboardData`)

2.  added the below line ⬇️  in case backend API fails to give dashboardData.
    `const sourceData = dashboardData || [];`

## Discord Details (!important):
Apurv Chimralwar#6827

