### PR TITLE
Refactor: changing superteam handbook  button text and link

### DIFF
--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -138,9 +138,9 @@ const DashboardHeader = ({
             variant={'unstyled'}
             w="12rem"
             fontSize={"14px"}
-            onClick={() => window.open("https://superteam-onboarding.gitbook.io/the-superteam-handbook/community/the-reputation-system")}
+            onClick={() => window.open("https://docs.superteam.fun/the-superteam-handbook/community/the-reputation-system")}
           >
-            Superteam Handbook
+            Learn More
           </Button>
         </VStack>
 


### PR DESCRIPTION
# fix: Changed the button text and URL on the Superteam Community page


## Proposed changes (including videos or screenshots)

Changed the button text on the Superteam Community page from "Superteam Handbook" to "Learn More" and updated the URL to https://docs.superteam.fun/the-superteam-handbook/community/the-reputation-system. See screenshot below:

<img width="542" alt="Screenshot 2023-06-12 at 9 35 47 PM" src="https://github.com/SuperteamDAO/superteam-reputation/assets/69411088/e60d0e1e-34d8-4133-aa56-7d76e4a62763">


## Discord Details 
Discord: @thisisSamridh#2253